### PR TITLE
feat: Add Price Segment API endpoint support

### DIFF
--- a/.github/ai-endpoint.example.md
+++ b/.github/ai-endpoint.example.md
@@ -1,19 +1,19 @@
-I am looking to extend this Recurly NestJS API wrapper to include Measured Unit
+I am looking to extend this Recurly NestJS API wrapper to include Price Segment
 
-API documentation: https://recurly.com/developers/api/v2021-02-25/index.html#tag/measured_unit
+API documentation: https://recurly.com/developers/api/v2021-02-25/index.html#tag/price_segment
 Local swagger downloaded version: `./recurly-api-spec.yaml`
 
-Before starting the work you should create a branch `api-endpoint-measured-unit` and ensure all development happens on that feature branch.
+Before starting the work you should create a branch `api-endpoint-price-segment` and ensure all development happens on that feature branch.
 
 You should use `src/v3/plan/*` as a template
 
-1. Create a new folder `src/v3/measured_unit` for the new files
-2. Create the `src/v3/measured_unit/measured_unit.types.ts` using the response entities from the API documentation. All type names should start with Recurly to help differentiate them in the clients applications. 
-3. Create the `src/v3/measured_unit/measured_unit.dtos.ts` using the API request Query/Body data from the API documentation. All DTOs names should start with Recurly to help differentiate them in the clients applications. 
-4. Create the `src/v3/measured_unit/measured_unit.service.ts` creating the actions for each endpoint in the API documentation,using the types, dtos etc, each endpoint should have a corresponding function, also accept API key as a param if clients want to pass at runtime. 
-5. Create the `src/v3/measured_unit/measured_unit.module.ts` for bringing everything together.
-6. Create the `src/v3/measured_unit/measured_unit.test.spec.ts` creating tests for each of the functions in the service file, ensure the tests pass successfully. Test should be created in the following CRUD order (create, read, update, delete) to ensure each service has data to pass to the others. Updates & Deletes should also read to ensure the change happened. Tests should call the relevant service functions and NOT mock responses. 
-7. Include the new module in the main `src/v3/v3.module.ts` file as an import
+1. Create a new folder `src/v3/priceSegment` for the new files
+2. Create the `src/v3/priceSegment/priceSegment.types.ts` using the response entities from the API documentation. All type names should start with Recurly to help differentiate them in the clients applications. 
+3. Create the `src/v3/priceSegment/priceSegment.dtos.ts` using the API request Query/Body data from the API documentation. All DTOs names should start with Recurly to help differentiate them in the clients applications. 
+4. Create the `src/v3/priceSegment/priceSegment.service.ts` creating the actions for each endpoint in the API documentation,using the types, dtos etc, each endpoint should have a corresponding function, also accept API key as a param if clients want to pass at runtime. 
+5. Create the `src/v3/priceSegment/priceSegment.module.ts` for bringing everything together.
+6. Create the `src/v3/priceSegment/priceSegment.test.spec.ts` creating tests for each of the functions in the service file, ensure the tests pass successfully. Test should be created in the following CRUD order (create, read, update, delete) to ensure each service has data to pass to the others. Updates & Deletes should also read to ensure the change happened. Tests should call the relevant service functions and NOT mock responses. 
+7. Include the new module in the main `src/v3/v3.module.ts` file as an import and export
 8. Add the new service, types and DTOs as exports to the main `src/index.ts` file
 9. Run lint and fix any linting issues (`npm run lint`)
 10. Run prettier (`npm run format`)

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ export { AddOnService } from './v3/plan/addon/addon.service'
 export { MeasuredUnitService } from './v3/measuredUnit/measuredUnit.service'
 export { CouponService } from './v3/coupon/coupon.service'
 export { UniqueCouponCodeService } from './v3/coupon/unique/unique.service'
+export { PriceSegmentService } from './v3/priceSegment/priceSegment.service'
 
 //Config
 export { RecurlyConfigDto } from './config/config.dto'
@@ -136,6 +137,14 @@ export {
 	RecurlyUniqueCouponCodeParams,
 } from './v3/coupon/unique/unique.types'
 
+export {
+	RecurlyPriceSegment,
+	RecurlyPriceSegmentList,
+	RecurlyPriceSegmentId,
+	RecurlyPriceSegmentCode,
+	RecurlyPriceSegmentIdOrCode,
+} from './v3/priceSegment/priceSegment.types'
+
 //DTOs
 export {
 	RecurlyListAccountsQueryDto,
@@ -209,3 +218,5 @@ export {
 export { CouponListParamsDto, CouponCreateDto, CouponUpdateDto } from './v3/coupon/coupon.dto'
 
 export { RecurlyGenerateUniqueCouponCodesDto, RecurlyListUniqueCouponCodesDto } from './v3/coupon/unique/unique.dto'
+
+export { RecurlyListPriceSegmentsQueryDto } from './v3/priceSegment/priceSegment.dto'

--- a/src/v3/priceSegment/priceSegment.dto.ts
+++ b/src/v3/priceSegment/priceSegment.dto.ts
@@ -1,0 +1,38 @@
+import { IsArray, IsOptional, IsString, IsNumber, IsEnum } from 'class-validator'
+
+/**
+ * Query parameters for listing price segments
+ */
+export class RecurlyListPriceSegmentsQueryDto {
+	/**
+	 * Filter results by their IDs. Up to 200 IDs can be passed at once using
+	 * commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
+	 *
+	 * **Important notes:**
+	 *
+	 * * The `ids` parameter cannot be used with any other ordering or filtering
+	 *   parameters (`limit`, `order`, `sort`, `begin_time`, `end_time`, etc)
+	 * * Invalid or unknown IDs will be ignored, so you should check that the
+	 *   results correspond to your request.
+	 * * Records are returned in an arbitrary order. Since results are all
+	 *   returned at once you can sort the records yourself.
+	 */
+	@IsOptional()
+	@IsArray()
+	@IsString({ each: true })
+	ids?: string[]
+
+	/**
+	 * Limit number of records 1-200.
+	 */
+	@IsOptional()
+	@IsNumber()
+	limit?: number
+
+	/**
+	 * Sort order.
+	 */
+	@IsOptional()
+	@IsEnum(['asc', 'desc'])
+	order?: 'asc' | 'desc'
+}

--- a/src/v3/priceSegment/priceSegment.module.ts
+++ b/src/v3/priceSegment/priceSegment.module.ts
@@ -1,0 +1,12 @@
+import { RecurlyConfigDto } from '../../config/config.dto'
+import { ConfigValidationModule } from '../../config/config.module'
+import { PriceSegmentService } from './priceSegment.service'
+import { Module } from '@nestjs/common'
+
+@Module({
+	imports: [ConfigValidationModule.register(RecurlyConfigDto)],
+	controllers: [],
+	providers: [PriceSegmentService],
+	exports: [PriceSegmentService],
+})
+export class PriceSegmentModule {}

--- a/src/v3/priceSegment/priceSegment.service.ts
+++ b/src/v3/priceSegment/priceSegment.service.ts
@@ -1,0 +1,56 @@
+import { RecurlyConfigDto } from '../../config/config.dto'
+import { InjectConfig } from '../../config/config.provider'
+import { RECURLY_API_BASE_URL } from '../v3.constants'
+import { buildQueryString, checkResponseIsOk, getHeaders } from '../v3.helpers'
+import { RecurlyListPriceSegmentsQueryDto } from './priceSegment.dto'
+import { RecurlyPriceSegment, RecurlyPriceSegmentList } from './priceSegment.types'
+import { Injectable, Logger } from '@nestjs/common'
+
+@Injectable()
+export class PriceSegmentService {
+	private readonly logger = new Logger(PriceSegmentService.name)
+
+	constructor(@InjectConfig(RecurlyConfigDto) private readonly config: RecurlyConfigDto) {}
+
+	/**
+	 * List a site's price segments
+	 * @param params Query parameters for filtering and pagination
+	 * @param apiKey Optional API key to override the default configuration
+	 * @returns A list of price segments
+	 */
+	async listPriceSegments(
+		params?: RecurlyListPriceSegmentsQueryDto,
+		apiKey?: string,
+	): Promise<RecurlyPriceSegmentList> {
+		let url = `${RECURLY_API_BASE_URL}/price_segments`
+
+		if (params && Object.keys(params).length > 0) {
+			url += '?' + buildQueryString(params)
+		}
+
+		const response = await fetch(url, {
+			method: 'GET',
+			headers: getHeaders(this.config, apiKey),
+		})
+
+		await checkResponseIsOk(response, this.logger, 'List Price Segments')
+		return (await response.json()) as RecurlyPriceSegmentList
+	}
+
+	/**
+	 * Fetch a price segment
+	 * @param priceSegmentId The price segment ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`.
+	 *                       For code, use prefix `code-`, e.g. `code-gold`.
+	 * @param apiKey Optional API key to override the default configuration
+	 * @returns A price segment
+	 */
+	async getPriceSegment(priceSegmentId: string, apiKey?: string): Promise<RecurlyPriceSegment> {
+		const response = await fetch(`${RECURLY_API_BASE_URL}/price_segments/${priceSegmentId}`, {
+			method: 'GET',
+			headers: getHeaders(this.config, apiKey),
+		})
+
+		await checkResponseIsOk(response, this.logger, 'Get Price Segment')
+		return (await response.json()) as RecurlyPriceSegment
+	}
+}

--- a/src/v3/priceSegment/priceSegment.test.spec.ts
+++ b/src/v3/priceSegment/priceSegment.test.spec.ts
@@ -1,0 +1,101 @@
+import { canTest } from '../v3.helpers'
+import { RecurlyV3Module } from '../v3.module'
+import { PriceSegmentService } from './priceSegment.service'
+import { RecurlyPriceSegment } from './priceSegment.types'
+import { ConfigModule } from '@nestjs/config'
+import { Test, TestingModule } from '@nestjs/testing'
+
+describe('PriceSegmentService', () => {
+	let service: PriceSegmentService
+	let firstPriceSegment: RecurlyPriceSegment | undefined
+
+	beforeAll(async () => {
+		if (!canTest()) {
+			console.log('Skipping Recurly tests - environment variables not set')
+			return
+		}
+
+		const moduleRef: TestingModule = await Test.createTestingModule({
+			imports: [ConfigModule.forRoot(), RecurlyV3Module],
+		}).compile()
+
+		service = moduleRef.get<PriceSegmentService>(PriceSegmentService)
+	})
+
+	describe('Price Segment Operations', () => {
+		// READ - List price segments
+		it('should list price segments', async () => {
+
+			const response = await service.listPriceSegments({
+				limit: 10,
+				order: 'asc',
+			})
+
+			expect(response).toBeDefined()
+			expect(response.object).toBe('list')
+			expect(Array.isArray(response.data)).toBe(true)
+
+			// If there are price segments, store the first one for the next test
+			if (response.data && response.data.length > 0) {
+				firstPriceSegment = response.data[0]
+			}
+		})
+
+		// READ - Get single price segment by ID
+		it('should get a price segment by ID', async () => {
+
+			// Skip if no price segments exist
+			if (!firstPriceSegment || !firstPriceSegment.id) {
+				console.log('No price segments found to test get by ID')
+				return
+			}
+
+			const priceSegment = await service.getPriceSegment(firstPriceSegment.id)
+
+			expect(priceSegment).toBeDefined()
+			expect(priceSegment.id).toBe(firstPriceSegment.id)
+			expect(priceSegment.code).toBe(firstPriceSegment.code)
+			expect(priceSegment.object).toBe('price_segment')
+		})
+
+		// READ - Get single price segment by code
+		it('should get a price segment by code', async () => {
+
+			// Skip if no price segments exist or no code is available
+			if (!firstPriceSegment || !firstPriceSegment.code) {
+				console.log('No price segments with code found to test get by code')
+				return
+			}
+
+			const priceSegment = await service.getPriceSegment(`code-${firstPriceSegment.code}`)
+
+			expect(priceSegment).toBeDefined()
+			expect(priceSegment.id).toBe(firstPriceSegment.id)
+			expect(priceSegment.code).toBe(firstPriceSegment.code)
+			expect(priceSegment.object).toBe('price_segment')
+		})
+
+		// READ - List price segments with specific IDs filter
+		it('should list price segments with specific IDs', async () => {
+
+			// Skip if no price segments exist
+			if (!firstPriceSegment || !firstPriceSegment.id) {
+				console.log('No price segments found to test list with IDs filter')
+				return
+			}
+
+			const response = await service.listPriceSegments({
+				ids: [firstPriceSegment.id],
+			})
+
+			expect(response).toBeDefined()
+			expect(response.object).toBe('list')
+			expect(Array.isArray(response.data)).toBe(true)
+			expect(response.data?.length).toBeGreaterThanOrEqual(1)
+
+			// Check if the requested price segment is in the response
+			const foundPriceSegment = response.data?.find(ps => ps.id === firstPriceSegment!.id)
+			expect(foundPriceSegment).toBeDefined()
+		})
+	})
+})

--- a/src/v3/priceSegment/priceSegment.types.ts
+++ b/src/v3/priceSegment/priceSegment.types.ts
@@ -1,0 +1,62 @@
+// Price Segment Types based on Recurly API v2021-02-25
+
+/**
+ * Represents a Price Segment object from Recurly
+ */
+export interface RecurlyPriceSegment {
+	/**
+	 * Object type - will always be 'price_segment'
+	 */
+	object?: string
+
+	/**
+	 * The price segment ID, e.g. `e28zov4fw0v2`
+	 */
+	id?: string
+
+	/**
+	 * The price segment code, e.g. `my-price-segment`
+	 */
+	code?: string
+}
+
+/**
+ * Represents a list of Price Segments from Recurly
+ */
+export interface RecurlyPriceSegmentList {
+	/**
+	 * Object type - will always be 'list'
+	 */
+	object?: string
+
+	/**
+	 * Indicates there are more results on subsequent pages
+	 */
+	has_more?: boolean
+
+	/**
+	 * Path to subsequent page of results
+	 */
+	next?: string
+
+	/**
+	 * Array of Price Segment objects
+	 */
+	data?: RecurlyPriceSegment[]
+}
+
+/**
+ * The price segment ID, e.g. `e28zov4fw0v2`
+ */
+export type RecurlyPriceSegmentId = string
+
+/**
+ * The price segment code, e.g. `my-price-segment`
+ */
+export type RecurlyPriceSegmentCode = string
+
+/**
+ * The price segment ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`.
+ * For requests, the code can also be used. Use prefix `code-`, e.g. `code-gold`.
+ */
+export type RecurlyPriceSegmentIdOrCode = string

--- a/src/v3/v3.module.ts
+++ b/src/v3/v3.module.ts
@@ -5,6 +5,7 @@ import { CouponModule } from './coupon/coupon.module'
 import { ItemModule } from './item/item.module'
 import { MeasuredUnitModule } from './measuredUnit/measuredUnit.module'
 import { PlanModule } from './plan/plan.module'
+import { PriceSegmentModule } from './priceSegment/priceSegment.module'
 import { Module } from '@nestjs/common'
 
 @Module({
@@ -15,7 +16,8 @@ import { Module } from '@nestjs/common'
 		PlanModule,
 		MeasuredUnitModule,
 		CouponModule,
+		PriceSegmentModule,
 	],
-	exports: [AccountsModule, ItemModule, PlanModule, MeasuredUnitModule, CouponModule],
+	exports: [AccountsModule, ItemModule, PlanModule, MeasuredUnitModule, CouponModule, PriceSegmentModule],
 })
 export class RecurlyV3Module {}


### PR DESCRIPTION
## Description
This PR adds support for Recurly's Price Segment API endpoints to the NestJS wrapper.

## Changes
- Created new `priceSegment` module following the existing pattern
- Added types for `RecurlyPriceSegment`, `RecurlyPriceSegmentList`, and related ID/Code types
- Added DTOs for list query parameters
- Implemented service with `listPriceSegments` and `getPriceSegment` methods
- Created comprehensive tests for all operations
- Integrated module into v3 module and main exports

## API Endpoints Implemented
- **GET /price_segments** - List all price segments
- **GET /price_segments/{price_segment_id}** - Get a specific price segment by ID or code

## Testing
- All tests are passing
- Linting and formatting completed successfully
- Build successful

## Notes
Price Segments are read-only in the Recurly API, so only list and get operations are implemented (no create, update, or delete).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduces Price Segment feature with public API access to list and retrieve price segments.
  - Supports optional filters and controls when listing: ids, limit, and order (asc/desc).
  - Exposes corresponding service, types, and DTOs via public exports.

- Documentation
  - Updates all references and guidance from “Measured Unit” to “Price Segment,” including API tags and workflow steps.

- Tests
  - Adds tests for listing, fetching by ID/code, and filtering by specific IDs to validate new functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->