### PR TITLE
feat: Add Site API endpoint support

### DIFF
--- a/.github/ai-endpoint.example.md
+++ b/.github/ai-endpoint.example.md
@@ -1,18 +1,18 @@
-I am looking to extend this Recurly NestJS API wrapper to include Transaction
+I am looking to extend this Recurly NestJS API wrapper to include Site
 
-API documentation: https://recurly.com/developers/api/v2021-02-25/#tag/transaction 
+API documentation: https://recurly.com/developers/api/v2021-02-25/#tag/site
 Local swagger downloaded version: `./recurly-api-spec.yaml`
 
-Before starting the work you should create a branch `api-endpoint-transaction` and ensure all development happens on that feature branch.
+Before starting the work you should create a branch `api-endpoint-sites` and ensure all development happens on that feature branch.
 
-You should use `src/v3/plan/*` as a template
+You should use `src/v3/ProductsPromotions/plan/*` as a template
 
-1. Create a new folder `src/v3/transaction` for the new files
-2. Create the `src/v3/transaction/transaction.types.ts` using the response entities from the API documentation. All type names should start with Recurly to help differentiate them in the clients applications. 
-3. Create the `src/v3/transaction/transaction.dtos.ts` using the API request Query/Body data from the API documentation. All DTOs names should start with Recurly to help differentiate them in the clients applications. 
-4. Create the `src/v3/transaction/transaction.service.ts` creating the actions for each endpoint in the API documentation, using the types, dtos etc, each endpoint should have a corresponding function, also accept API key as a param if clients want to pass at runtime. 
-5. Create the `src/v3/transaction/transaction.module.ts` for bringing everything together.
-6. Create the `src/v3/transaction/transaction.test.spec.ts` creating tests for each of the functions in the service file, ensure the tests pass successfully. Test should be created in the following CRUD order (create, read, update, delete) to ensure each service has data to pass to the others. Updates & Deletes should also read to ensure the change happened. Tests should call the relevant service functions and NOT mock responses. 
+1. Create a new folder `src/v3/Configuration/site` for the new files
+2. Create the `src/v3/Configuration/site/site.types.ts` using the response entities from the API documentation. All type names should start with Recurly to help differentiate them in the clients applications. 
+3. Create the `src/v3/Configuration/site/site.dtos.ts` using the API request Query/Body data from the API documentation. All DTOs names should start with Recurly to help differentiate them in the clients applications. 
+4. Create the `src/v3/Configuration/site/site.service.ts` creating the actions for each endpoint in the API documentation, using the types, dtos etc, each endpoint should have a corresponding function, also accept API key as a param if clients want to pass at runtime. 
+5. Create the `src/v3/Configuration/site/site.module.ts` for bringing everything together.
+6. Create the `src/v3/Configuration/site/site.test.spec.ts` creating tests for each of the functions in the service file, ensure the tests pass successfully. Test should be created in the following CRUD order (create, read, update, delete) to ensure each service has data to pass to the others. Updates & Deletes should also read to ensure the change happened. Tests should call the relevant service functions and NOT mock responses. 
 7. Include the new module in the main `src/v3/v3.module.ts` file as an import and export
 8. Add the new service, types and DTOs as exports to the main `src/index.ts` file
 9. Run lint and fix any linting issues (`npm run lint`)

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ export { PurchaseService } from './v3/Customers/purchase/purchase.service'
 export { GiftCardService } from './v3/Customers/giftCards/giftCards.service'
 export { InvoiceService } from './v3/InvoicesPayments/invoice/invoice.service'
 export { LineItemService } from './v3/InvoicesPayments/lineItem/lineItem.service'
+export { SiteService } from './v3/Configuration/site/site.service'
 
 //Config
 export { RecurlyConfigDto } from '@config/config.dto'
@@ -198,6 +199,18 @@ export {
 	RecurlyLineItemListResponse,
 } from './v3/InvoicesPayments/lineItem/lineItem.types'
 
+// Site Types
+export {
+	RecurlySite,
+	RecurlySiteMini,
+	RecurlySiteListResponse,
+	RecurlySiteMode,
+	RecurlySiteFeature,
+	RecurlyBillingAddressRequirement,
+	RecurlyAddress as RecurlySiteAddress,
+	RecurlySiteSettings,
+} from './v3/Configuration/site/site.types'
+
 // Purchase Types
 export {
 	RecurlyBillingAddress,
@@ -364,3 +377,6 @@ export {
 } from './v3/InvoicesPayments/invoice/invoice.dto'
 
 export { RecurlyListLineItemsQueryDto, RecurlyCreateLineItemDto } from './v3/InvoicesPayments/lineItem/lineItem.dtos'
+
+// Site DTOs
+export { RecurlyListSitesQueryDto } from './v3/Configuration/site/site.dtos'

--- a/src/v3/Configuration/site/site.dtos.ts
+++ b/src/v3/Configuration/site/site.dtos.ts
@@ -1,0 +1,38 @@
+import { IsArray, IsOptional, IsString, IsEnum, IsNumber, IsDateString } from 'class-validator'
+
+// List Sites Query DTO
+export class RecurlyListSitesQueryDto {
+	@IsOptional()
+	@IsArray()
+	@IsString({ each: true })
+	ids?: string[]
+
+	@IsOptional()
+	@IsNumber()
+	limit?: number
+
+	@IsOptional()
+	@IsEnum(['asc', 'desc'])
+	order?: 'asc' | 'desc'
+
+	@IsOptional()
+	@IsEnum(['created_at', 'updated_at'])
+	sort?: 'created_at' | 'updated_at'
+
+	@IsOptional()
+	@IsDateString()
+	begin_time?: string
+
+	@IsOptional()
+	@IsDateString()
+	end_time?: string
+
+	@IsOptional()
+	@IsEnum(['active', 'inactive'])
+	state?: 'active' | 'inactive'
+}
+
+// Note: Site endpoints in Recurly API are read-only
+// The API documentation shows only GET operations (list_sites and get_site)
+// No create, update, or delete operations are available for sites
+// Sites are managed through the Recurly dashboard

--- a/src/v3/Configuration/site/site.module.ts
+++ b/src/v3/Configuration/site/site.module.ts
@@ -1,0 +1,12 @@
+import { SiteService } from './site.service'
+import { RecurlyConfigDto } from '@config/config.dto'
+import { ConfigValidationModule } from '@config/config.module'
+import { Module } from '@nestjs/common'
+
+@Module({
+	imports: [ConfigValidationModule.register(RecurlyConfigDto)],
+	controllers: [],
+	providers: [SiteService],
+	exports: [SiteService],
+})
+export class SiteModule {}

--- a/src/v3/Configuration/site/site.service.ts
+++ b/src/v3/Configuration/site/site.service.ts
@@ -1,0 +1,40 @@
+import { RECURLY_API_BASE_URL } from '../../v3.constants'
+import { buildQueryString, checkResponseIsOk, getHeaders } from '../../v3.helpers'
+import { RecurlyListSitesQueryDto } from './site.dtos'
+import { RecurlySite, RecurlySiteListResponse } from './site.types'
+import { RecurlyConfigDto } from '@config/config.dto'
+import { InjectConfig } from '@config/config.provider'
+import { Injectable, Logger } from '@nestjs/common'
+
+@Injectable()
+export class SiteService {
+	private readonly logger = new Logger(SiteService.name)
+
+	constructor(@InjectConfig(RecurlyConfigDto) private readonly config: RecurlyConfigDto) {}
+
+	async listSites(params?: RecurlyListSitesQueryDto, apiKey?: string): Promise<RecurlySiteListResponse> {
+		let url = `${RECURLY_API_BASE_URL}/sites`
+
+		if (params && Object.keys(params).length > 0) {
+			url += '?' + buildQueryString(params)
+		}
+
+		const response = await fetch(url, {
+			method: 'GET',
+			headers: getHeaders(this.config, apiKey),
+		})
+
+		await checkResponseIsOk(response, this.logger, 'List Sites')
+		return (await response.json()) as RecurlySiteListResponse
+	}
+
+	async getSite(siteId: string, apiKey?: string): Promise<RecurlySite> {
+		const response = await fetch(`${RECURLY_API_BASE_URL}/sites/${siteId}`, {
+			method: 'GET',
+			headers: getHeaders(this.config, apiKey),
+		})
+
+		await checkResponseIsOk(response, this.logger, 'Get Site')
+		return (await response.json()) as RecurlySite
+	}
+}

--- a/src/v3/Configuration/site/site.test.spec.ts
+++ b/src/v3/Configuration/site/site.test.spec.ts
@@ -1,0 +1,61 @@
+import { canTest } from '../../v3.helpers'
+import { RecurlyV3Module } from '../../v3.module'
+import { SiteService } from './site.service'
+import { ConfigModule } from '@nestjs/config'
+import { Test, TestingModule } from '@nestjs/testing'
+
+describe('SiteService', () => {
+	let service: SiteService
+	let siteId: string
+
+	beforeAll(async () => {
+		if (!canTest()) {
+			console.log('Skipping Recurly tests - environment variables not set')
+			return
+		}
+
+		const moduleRef: TestingModule = await Test.createTestingModule({
+			imports: [ConfigModule.forRoot(), RecurlyV3Module],
+		}).compile()
+
+		service = moduleRef.get<SiteService>(SiteService)
+	})
+
+	describe('Site Operations', () => {
+		it('should list sites', async () => {
+			const sites = await service.listSites()
+			expect(sites).toBeDefined()
+			expect(sites.data).toBeDefined()
+			expect(Array.isArray(sites.data)).toBe(true)
+
+			// Store the first site ID for subsequent tests
+			if (sites.data.length > 0) {
+				siteId = sites.data[0].id!
+			}
+		})
+
+		it('should get a specific site', async () => {
+			if (!siteId) {
+				console.warn('Skipping get site test - no site ID available')
+				return
+			}
+
+			const site = await service.getSite(siteId)
+			expect(site).toBeDefined()
+			expect(site.id).toBe(siteId)
+			expect(site.subdomain).toBeDefined()
+		})
+
+		it('should list sites with query parameters', async () => {
+
+			const sites = await service.listSites({
+				limit: 1,
+				order: 'asc',
+				sort: 'created_at',
+			})
+			expect(sites).toBeDefined()
+			expect(sites.data).toBeDefined()
+			expect(Array.isArray(sites.data)).toBe(true)
+		})
+	})
+})

--- a/src/v3/Configuration/site/site.types.ts
+++ b/src/v3/Configuration/site/site.types.ts
@@ -1,0 +1,52 @@
+// Enums
+export type RecurlySiteMode = 'development' | 'production' | 'sandbox'
+
+export type RecurlySiteFeature = 'credit_memos' | 'manual_invoicing' | 'only_bill_what_changed' | 'subscription_terms'
+
+export type RecurlyBillingAddressRequirement = 'full' | 'none' | 'streetzip' | 'zip'
+
+// Address interface
+export interface RecurlyAddress {
+	phone?: string
+	street1?: string
+	street2?: string
+	city?: string
+	region?: string
+	postal_code?: string
+	country?: string
+	geo_code?: string
+}
+
+// Site Settings interface
+export interface RecurlySiteSettings {
+	billing_address_requirement?: RecurlyBillingAddressRequirement
+	accepted_currencies?: string[]
+	default_currency?: string
+}
+
+// Site Mini interface
+export interface RecurlySiteMini {
+	id?: string
+	object?: string
+	subdomain?: string
+}
+
+// Full Site interface
+export interface RecurlySite extends RecurlySiteMini {
+	public_api_key?: string
+	mode?: RecurlySiteMode
+	address?: RecurlyAddress
+	settings?: RecurlySiteSettings
+	features?: RecurlySiteFeature[]
+	created_at?: string
+	updated_at?: string
+	deleted_at?: string
+}
+
+// Site List Response
+export interface RecurlySiteListResponse {
+	object?: string
+	has_more?: boolean
+	next?: string
+	data: RecurlySite[]
+}

--- a/src/v3/v3.module.ts
+++ b/src/v3/v3.module.ts
@@ -1,3 +1,4 @@
+import { SiteModule } from './Configuration/site/site.module'
 import { AccountsModule } from './Customers/accounts/accounts.module'
 import { GiftCardModule } from './Customers/giftCards/giftCards.module'
 import { PurchaseModule } from './Customers/purchase/purchase.module'
@@ -31,6 +32,7 @@ import { Module } from '@nestjs/common'
 		PurchaseModule,
 		SubscriptionModule,
 		TransactionModule,
+		SiteModule,
 	],
 	exports: [
 		AccountsModule,
@@ -46,6 +48,7 @@ import { Module } from '@nestjs/common'
 		PurchaseModule,
 		SubscriptionModule,
 		TransactionModule,
+		SiteModule,
 	],
 })
 export class RecurlyV3Module {}


### PR DESCRIPTION
Add support for Recurly Site API endpoints with read-only operations (listSites and getSite). Includes comprehensive types, tests, and proper integration with the existing module structure.